### PR TITLE
fix: static manager keeps reference to network configuration

### DIFF
--- a/Assets/Resources/NetworkConfiguration.asset
+++ b/Assets/Resources/NetworkConfiguration.asset
@@ -12,18 +12,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ab5daf6cd0c3f494aa5eb9161f250432, type: 3}
   m_Name: NetworkConfiguration
   m_EditorClassIdentifier: 
-  Color:
+  _username: Username
+  _color:
     serializedVersion: 2
     rgba: 4294967295
   _allowVirtualIPs: 0
-  LocalStringIPAddresses:
-  - 192.168.2.153
-  MTU: 1200
-  RTT: 200
-  ServerConnectionTimeout: 5000
-  ServerHeartbeatDelay: 1000
-  ServerDiscoveryTimeout: 3000
-  MaxNumberResendReliablePackets: 5
-  DiscoveryIP: 239.240.240.149
+  _mtu: 1200
+  _rtt: 200
+  _serverConnectionTimeout: 5000
+  _serverHeartbeatDelay: 1000
+  _serverDiscoveryTimeout: 3000
+  _maxNumberResendReliablePackets: 5
+  _discoveryIP: 239.240.240.149
+  _discoveryPort: 26824
   _showDebugMessages: 1
-  AllowLocalConnections: 1
+  _allowLocalConnections: 0

--- a/Assets/SimpleUnityNetworking/Editor/Scripts/Managing/StaticNetworkManagerWindow.cs
+++ b/Assets/SimpleUnityNetworking/Editor/Scripts/Managing/StaticNetworkManagerWindow.cs
@@ -11,13 +11,27 @@ namespace jKnepel.SimpleUnityNetworking.Managing
 {
     public class StaticNetworkManagerWindow : EditorWindow
     {
+        [SerializeField] private NetworkConfiguration _cachedNetworkConfiguration = null;
+        private NetworkConfiguration NetworkConfiguration
+        {
+            get => StaticNetworkManager.NetworkConfiguration;
+            set
+            {
+                if (_cachedNetworkConfiguration != value)
+                    _settingsEditor = null;
+
+                _cachedNetworkConfiguration = value;
+                StaticNetworkManager.NetworkConfiguration = _cachedNetworkConfiguration;
+            }
+        }
+
         private Editor _settingsEditor = null;
         public Editor SettingsEditor
         {
             get
             {
                 if (_settingsEditor == null)
-                    _settingsEditor = Editor.CreateEditor(StaticNetworkManager.NetworkConfiguration);
+                    _settingsEditor = Editor.CreateEditor(NetworkConfiguration);
                 return _settingsEditor;
             }
         }
@@ -85,8 +99,8 @@ namespace jKnepel.SimpleUnityNetworking.Managing
 
             GUILayout.Label("Network Manager", EditorStyles.largeLabel);
 
-            StaticNetworkManager.NetworkConfiguration = (NetworkConfiguration)EditorGUILayout.ObjectField(StaticNetworkManager.NetworkConfiguration, typeof(NetworkConfiguration), true);
-            if (StaticNetworkManager.NetworkConfiguration != null)
+            NetworkConfiguration = (NetworkConfiguration)EditorGUILayout.ObjectField(_cachedNetworkConfiguration, typeof(NetworkConfiguration), true);
+            if (NetworkConfiguration != null)
                 SettingsEditor.OnInspectorGUI();
 
             EditorGUILayout.Space();
@@ -230,7 +244,7 @@ namespace jKnepel.SimpleUnityNetworking.Managing
         }
 
         private void ShowSystemMessages()
-		{
+        {
             EditorGUILayout.BeginHorizontal();
             GUILayout.Label($"Network Messages:");
             GUILayout.FlexibleSpace();

--- a/Assets/SimpleUnityNetworking/Editor/Scripts/Networking/NetworkConfigurationEditor.cs
+++ b/Assets/SimpleUnityNetworking/Editor/Scripts/Networking/NetworkConfigurationEditor.cs
@@ -26,7 +26,9 @@ namespace jKnepel.SimpleUnityNetworking.Networking
                 EditorGUI.indentLevel++;
 
                 settings.LocalIPAddressIndex = EditorGUILayout.Popup("Local IP Address:", settings.LocalIPAddressIndex, settings.LocalStringIPAddresses);
+                EditorGUI.BeginDisabledGroup(true);
                 EditorGUILayout.IntField(new GUIContent("Local Port:", "The Local Port used by the Network Socket. The Port is readonly and is assigned automatically upon starting a Socket."), settings.LocalPort);
+                EditorGUI.EndDisabledGroup();
                 EditorGUILayout.Space();
                 settings.MTU = EditorGUILayout.IntField("MTU:", settings.MTU);
                 settings.RTT = EditorGUILayout.IntField("RTT:", settings.RTT);

--- a/Assets/SimpleUnityNetworking/Runtime/Scripts/Managing/StaticNetworkManager.cs
+++ b/Assets/SimpleUnityNetworking/Runtime/Scripts/Managing/StaticNetworkManager.cs
@@ -8,6 +8,7 @@ using jKnepel.SimpleUnityNetworking.Networking.ServerDiscovery;
 using jKnepel.SimpleUnityNetworking.Networking.Sockets;
 using jKnepel.SimpleUnityNetworking.Utilities;
 using jKnepel.SimpleUnityNetworking.SyncDataTypes;
+using System.IO;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -16,472 +17,529 @@ namespace jKnepel.SimpleUnityNetworking.Managing
 {
     public static class StaticNetworkManager
     {
-		#region public members
+        #region public members
 
-		/// <summary>
-		/// The Configuration for the networking.
-		/// </summary>
-		public static NetworkConfiguration NetworkConfiguration;
-		/// <summary>
-		/// Wether the local client is currently connected to or hosting a server.
-		/// </summary>
-		public static bool IsConnected => _networkSocket?.IsConnected ?? false;
-		/// <summary>
-		/// Wether the local client is currently hosting a lobby.
-		/// </summary>
-		public static bool IsHost => ClientInformation?.IsHost ?? false;
-		/// <summary>
-		/// The current connection status of the local client.
-		/// </summary>
-		public static EConnectionStatus ConnectionStatus => _networkSocket?.ConnectionStatus ?? EConnectionStatus.IsDisconnected;
-		/// <summary>
-		/// Information on the server the client is currently connected to.
-		/// </summary>
-		public static ServerInformation ServerInformation => _networkSocket?.ServerInformation ?? null;
-		/// <summary>
-		/// Information on the local clients information associated with the server they are connected to.
-		/// </summary>
-		public static ClientInformation ClientInformation => _networkSocket?.ClientInformation ?? null;
-		/// <summary>
-		/// All other clients that are connected to the same server as the local client.
-		/// </summary>
-		public static ConcurrentDictionary<byte, ClientInformation> ConnectedClients => _networkSocket?.ConnectedClients ?? null;
-		/// <summary>
-		/// The number of connected clients.
-		/// </summary>
-		public static byte NumberConnectedClients => (byte)(ConnectedClients?.Values.Count ?? 0);
+        /// <summary>
+        /// The Configuration for the networking.
+        /// </summary>
+        public static NetworkConfiguration NetworkConfiguration
+        {
+            get
+            {
+                if (_networkConfiguration == null)
+                    _networkConfiguration = LoadOrCreateConfiguration<NetworkConfiguration>();
+                return _networkConfiguration;
+            }
+            set => _networkConfiguration = value;
+        }
 
-		/// <summary>
-		/// Wether the server discovery is currently active or not.
-		/// </summary>
-		public static bool IsServerDiscoveryActive => _serverDiscovery?.IsActive ?? false;
-		/// <summary>
-		/// All open servers that the local client could connect to.
-		/// </summary>
-		public static List<OpenServer> OpenServers => _serverDiscovery?.OpenServers ?? null;
+        /// <summary>
+        /// Wether the local client is currently connected to or hosting a server.
+        /// </summary>
+        public static bool IsConnected => _networkSocket?.IsConnected ?? false;
+        /// <summary>
+        /// Wether the local client is currently hosting a lobby.
+        /// </summary>
+        public static bool IsHost => ClientInformation?.IsHost ?? false;
+        /// <summary>
+        /// The current connection status of the local client.
+        /// </summary>
+        public static EConnectionStatus ConnectionStatus => _networkSocket?.ConnectionStatus ?? EConnectionStatus.IsDisconnected;
+        /// <summary>
+        /// Information on the server the client is currently connected to.
+        /// </summary>
+        public static ServerInformation ServerInformation => _networkSocket?.ServerInformation ?? null;
+        /// <summary>
+        /// Information on the local clients information associated with the server they are connected to.
+        /// </summary>
+        public static ClientInformation ClientInformation => _networkSocket?.ClientInformation ?? null;
+        /// <summary>
+        /// All other clients that are connected to the same server as the local client.
+        /// </summary>
+        public static ConcurrentDictionary<byte, ClientInformation> ConnectedClients => _networkSocket?.ConnectedClients ?? null;
+        /// <summary>
+        /// The number of connected clients.
+        /// </summary>
+        public static byte NumberConnectedClients => (byte)(ConnectedClients?.Values.Count ?? 0);
 
-		/// <summary>
-		/// Action for when connection to or creation of a server is being started.
-		/// </summary>
-		public static Action OnConnecting;
-		/// <summary>
-		/// Action for when successfully connecting to or creating a Server.
-		/// </summary>
-		public static Action OnConnected;
-		/// <summary>
-		/// Action for when disconnecting from or closing the Server.
-		/// </summary>
-		public static Action OnDisconnected;
-		/// <summary>
-		/// Action for when the connection status of the local client was updated.
-		/// </summary>
-		public static Action OnConnectionStatusUpdated;
-		/// <summary>
-		/// Action for when the server the local client was connected to was closed.
-		/// </summary>
-		public static Action OnServerWasClosed;
-		/// <summary>
-		/// Action for when a remote Client connected to the current Server and can now receive Messages.
-		/// </summary>
-		public static Action<byte> OnClientConnected;
-		/// <summary>
-		/// Action for when a remote Client disconnected from the current Server and can no longer receive any Messages.
-		/// </summary>
-		public static Action<byte> OnClientDisconnected;
-		/// <summary>
-		/// Action for when a Client was added or removed from ConnectedClients.
-		/// </summary>
-		public static Action OnConnectedClientListUpdated;
-		/// <summary>
-		/// Action for when the Server Discovery was activated.
-		/// </summary>
-		public static Action OnServerDiscoveryActivated;
-		/// <summary>
-		/// Action for when the Server Discovery was deactivated.
-		/// </summary>
-		public static Action OnServerDiscoveryDeactivated;
-		/// <summary>
-		/// Action for when a Server was added or removed from the OpenServers.
-		/// </summary>
-		public static Action OnOpenServerListUpdated;
-		/// <summary>
-		/// Action for when a new Network Message was added.
-		/// </summary>
-		public static Action OnNetworkMessageAdded;
+        /// <summary>
+        /// Wether the server discovery is currently active or not.
+        /// </summary>
+        public static bool IsServerDiscoveryActive => _serverDiscovery?.IsActive ?? false;
+        /// <summary>
+        /// All open servers that the local client could connect to.
+        /// </summary>
+        public static List<OpenServer> OpenServers => _serverDiscovery?.OpenServers ?? null;
 
-		#endregion
+        /// <summary>
+        /// Action for when connection to or creation of a server is being started.
+        /// </summary>
+        public static Action OnConnecting;
+        /// <summary>
+        /// Action for when successfully connecting to or creating a Server.
+        /// </summary>
+        public static Action OnConnected;
+        /// <summary>
+        /// Action for when disconnecting from or closing the Server.
+        /// </summary>
+        public static Action OnDisconnected;
+        /// <summary>
+        /// Action for when the connection status of the local client was updated.
+        /// </summary>
+        public static Action OnConnectionStatusUpdated;
+        /// <summary>
+        /// Action for when the server the local client was connected to was closed.
+        /// </summary>
+        public static Action OnServerWasClosed;
+        /// <summary>
+        /// Action for when a remote Client connected to the current Server and can now receive Messages.
+        /// </summary>
+        public static Action<byte> OnClientConnected;
+        /// <summary>
+        /// Action for when a remote Client disconnected from the current Server and can no longer receive any Messages.
+        /// </summary>
+        public static Action<byte> OnClientDisconnected;
+        /// <summary>
+        /// Action for when a Client was added or removed from ConnectedClients.
+        /// </summary>
+        public static Action OnConnectedClientListUpdated;
+        /// <summary>
+        /// Action for when the Server Discovery was activated.
+        /// </summary>
+        public static Action OnServerDiscoveryActivated;
+        /// <summary>
+        /// Action for when the Server Discovery was deactivated.
+        /// </summary>
+        public static Action OnServerDiscoveryDeactivated;
+        /// <summary>
+        /// Action for when a Server was added or removed from the OpenServers.
+        /// </summary>
+        public static Action OnOpenServerListUpdated;
+        /// <summary>
+        /// Action for when a new Network Message was added.
+        /// </summary>
+        public static Action OnNetworkMessageAdded;
 
-		#region private members
+        #endregion
 
-		private static ANetworkSocket _networkSocket;
-		private static ServerDiscoveryManager _serverDiscovery;
+        #region private members
 
-		#endregion
+        private static NetworkConfiguration _networkConfiguration;
+        private static ANetworkSocket _networkSocket;
+        private static ServerDiscoveryManager _serverDiscovery;
 
-		#region lifecycle
+        #endregion
 
-		static StaticNetworkManager()
-		{
-			if (NetworkConfiguration == null)
-				NetworkConfiguration = (NetworkConfiguration)ScriptableObject.CreateInstance(typeof(NetworkConfiguration));
+        #region lifecycle
 
-			Messaging.OnNetworkMessageAdded += FireOnNetworkMessageAdded;
-			StartServerDiscovery();
-		}
+        static StaticNetworkManager()
+        {
+            Messaging.OnNetworkMessageAdded += FireOnNetworkMessageAdded;
+            StartServerDiscovery();
+        }
 
-		#endregion
+        #endregion
 
-		#region public methods
+        #region public methods
 
-		/// <summary>
-		/// Creates a new server with the local client has host.
-		/// </summary>
-		/// <param name="servername"></param>
-		/// <param name="maxNumberClients"></param>
-		/// <param name="onConnectionEstablished">Will be called once the server was successfully or failed to be created</param>
-		public static void CreateServer(string servername, byte maxNumberClients, Action<bool> onConnectionEstablished = null)
-		{
+        /// <summary>
+        /// Creates a new server with the local client has host.
+        /// </summary>
+        /// <param name="servername"></param>
+        /// <param name="maxNumberClients"></param>
+        /// <param name="onConnectionEstablished">Will be called once the server was successfully or failed to be created</param>
+        public static void CreateServer(string servername, byte maxNumberClients, Action<bool> onConnectionEstablished = null)
+        {
 #if UNITY_EDITOR
-			if (Application.isPlaying)
-				return;
+            if (Application.isPlaying)
+                return;
 #endif
 
-			if (IsConnected)
-			{
-				Messaging.DebugMessage("The Client is already hosting a server!");
-				onConnectionEstablished?.Invoke(false);
-				return;
-			}
+            if (IsConnected)
+            {
+                Messaging.DebugMessage("The Client is already hosting a server!");
+                onConnectionEstablished?.Invoke(false);
+                return;
+            }
 
-			NetworkServer server = new();
-			_networkSocket = server;
-			server.OnConnecting += FireOnConnecting;
-			server.OnConnected += FireOnConnected;
-			server.OnDisconnected += FireOnDisconnected;
-			server.OnConnectionStatusUpdated += FireOnConnectionStatusUpdated;
-			server.OnServerWasClosed += FireOnServerWasClosed;
-			server.OnClientConnected += FireOnClientConnected;
-			server.OnClientDisconnected += FireOnClientDisconnected;
-			server.OnConnectedClientListUpdated += FireOnConnectedClientListUpdated;
+            NetworkServer server = new();
+            _networkSocket = server;
+            server.OnConnecting += FireOnConnecting;
+            server.OnConnected += FireOnConnected;
+            server.OnDisconnected += FireOnDisconnected;
+            server.OnConnectionStatusUpdated += FireOnConnectionStatusUpdated;
+            server.OnServerWasClosed += FireOnServerWasClosed;
+            server.OnClientConnected += FireOnClientConnected;
+            server.OnClientDisconnected += FireOnClientDisconnected;
+            server.OnConnectedClientListUpdated += FireOnConnectedClientListUpdated;
+
+#if UNITY_EDITOR
+
+            onConnectionEstablished += ListenForStateChange;
+#endif
+
+            server.StartServer(NetworkConfiguration, servername, maxNumberClients, onConnectionEstablished);
+        }
+
+        /// <summary>
+        /// Joins an open server as client.
+        /// </summary>
+        /// <param name="serverIP"></param>
+        /// <param name="serverPort"></param>
+        /// <param name="onConnectionEstablished">Will be called once the connection to the server was successfully or failed to be created</param>
+        public static void JoinServer(IPAddress serverIP, int serverPort, Action<bool> onConnectionEstablished = null)
+        {
+#if UNITY_EDITOR
+            if (Application.isPlaying)
+                return;
+#endif
+
+            if (IsConnected)
+            {
+                Messaging.DebugMessage("The Client is already connected to a server!");
+                onConnectionEstablished?.Invoke(false);
+                return;
+            }
+
+            NetworkClient client = new();
+            _networkSocket = client;
+            client.OnConnecting += FireOnConnecting;
+            client.OnConnected += FireOnConnected;
+            client.OnDisconnected += FireOnDisconnected;
+            client.OnConnectionStatusUpdated += FireOnConnectionStatusUpdated;
+            client.OnServerWasClosed += FireOnServerWasClosed;
+            client.OnClientConnected += FireOnClientConnected;
+            client.OnClientDisconnected += FireOnClientDisconnected;
+            client.OnConnectedClientListUpdated += FireOnConnectedClientListUpdated;
 
 #if UNITY_EDITOR
 
-			onConnectionEstablished += ListenForStateChange;
+            onConnectionEstablished += ListenForStateChange;
 #endif
 
-			server.StartServer(NetworkConfiguration, servername, maxNumberClients, onConnectionEstablished);
-		}
+            client.ConnectToServer(NetworkConfiguration, serverIP, serverPort, onConnectionEstablished);
+        }
 
-		/// <summary>
-		/// Joins an open server as client.
-		/// </summary>
-		/// <param name="serverIP"></param>
-		/// <param name="serverPort"></param>
-		/// <param name="onConnectionEstablished">Will be called once the connection to the server was successfully or failed to be created</param>
-		public static void JoinServer(IPAddress serverIP, int serverPort, Action<bool> onConnectionEstablished = null)
-		{
-#if UNITY_EDITOR
-			if (Application.isPlaying)
-				return;
-#endif
+        /// <summary>
+        /// Disconnects from the current server. Also closes the server if the local client is the host.
+        /// </summary>
+        public static void DisconnectFromServer()
+        {
+            if (_networkSocket == null)
+                return;
 
-			if (IsConnected)
-			{
-				Messaging.DebugMessage("The Client is already connected to a server!");
-				onConnectionEstablished?.Invoke(false);
-				return;
-			}
+            if (IsConnected)
+                _networkSocket.DisconnectFromServer();
 
-			NetworkClient client = new();
-			_networkSocket = client;
-			client.OnConnecting += FireOnConnecting;
-			client.OnConnected += FireOnConnected;
-			client.OnDisconnected += FireOnDisconnected;
-			client.OnConnectionStatusUpdated += FireOnConnectionStatusUpdated;
-			client.OnServerWasClosed += FireOnServerWasClosed;
-			client.OnClientConnected += FireOnClientConnected;
-			client.OnClientDisconnected += FireOnClientDisconnected;
-			client.OnConnectedClientListUpdated += FireOnConnectedClientListUpdated;
-
-#if UNITY_EDITOR
-			
-			onConnectionEstablished += ListenForStateChange;
-#endif
-
-			client.ConnectToServer(NetworkConfiguration, serverIP, serverPort, onConnectionEstablished);
-		}
-
-		/// <summary>
-		/// Disconnects from the current server. Also closes the server if the local client is the host.
-		/// </summary>
-		public static void DisconnectFromServer()
-		{
-			if (_networkSocket == null)
-				return;
-
-			if (IsConnected)
-				_networkSocket.DisconnectFromServer();
-
-			switch (_networkSocket)
-			{
-				case NetworkServer server:
-					server.OnConnecting -= FireOnConnecting;
-					server.OnConnected -= FireOnConnected;
-					server.OnDisconnected -= FireOnDisconnected;
-					server.OnConnectionStatusUpdated -= FireOnConnectionStatusUpdated;
-					server.OnServerWasClosed -= FireOnServerWasClosed;
-					server.OnClientConnected -= FireOnClientConnected;
-					server.OnClientDisconnected -= FireOnClientDisconnected;
-					server.OnConnectedClientListUpdated -= FireOnConnectedClientListUpdated;
-					break;
-				case NetworkClient client:
-					client.OnConnecting -= FireOnConnecting;
-					client.OnConnected -= FireOnConnected;
-					client.OnDisconnected -= FireOnDisconnected;
-					client.OnConnectionStatusUpdated -= FireOnConnectionStatusUpdated;
-					client.OnServerWasClosed -= FireOnServerWasClosed;
-					client.OnClientConnected -= FireOnClientConnected;
-					client.OnClientDisconnected -= FireOnClientDisconnected;
-					client.OnConnectedClientListUpdated -= FireOnConnectedClientListUpdated;
-					break;
-			}
-			_networkSocket = null;
+            switch (_networkSocket)
+            {
+                case NetworkServer server:
+                    server.OnConnecting -= FireOnConnecting;
+                    server.OnConnected -= FireOnConnected;
+                    server.OnDisconnected -= FireOnDisconnected;
+                    server.OnConnectionStatusUpdated -= FireOnConnectionStatusUpdated;
+                    server.OnServerWasClosed -= FireOnServerWasClosed;
+                    server.OnClientConnected -= FireOnClientConnected;
+                    server.OnClientDisconnected -= FireOnClientDisconnected;
+                    server.OnConnectedClientListUpdated -= FireOnConnectedClientListUpdated;
+                    break;
+                case NetworkClient client:
+                    client.OnConnecting -= FireOnConnecting;
+                    client.OnConnected -= FireOnConnected;
+                    client.OnDisconnected -= FireOnDisconnected;
+                    client.OnConnectionStatusUpdated -= FireOnConnectionStatusUpdated;
+                    client.OnServerWasClosed -= FireOnServerWasClosed;
+                    client.OnClientConnected -= FireOnClientConnected;
+                    client.OnClientDisconnected -= FireOnClientDisconnected;
+                    client.OnConnectedClientListUpdated -= FireOnConnectedClientListUpdated;
+                    break;
+            }
+            _networkSocket = null;
 
 #if UNITY_EDITOR
-			ListenForStateChange(false);
+            ListenForStateChange(false);
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Starts the Server Discovery unless it is already active.
-		/// </summary>
-		public static void StartServerDiscovery()
-		{
-			if (_serverDiscovery != null && _serverDiscovery.IsActive)
-				return;
+        /// <summary>
+        /// Starts the Server Discovery unless it is already active.
+        /// </summary>
+        public static void StartServerDiscovery()
+        {
+            if (_serverDiscovery != null && _serverDiscovery.IsActive)
+                return;
 
-			_serverDiscovery = new();
-			_serverDiscovery.OnServerDiscoveryActivated += FireOnServerDiscoveryActivated;
-			_serverDiscovery.OnServerDiscoveryDeactivated += FireOnServerDiscoveryDeactivated;
-			_serverDiscovery.OnOpenServerListUpdated += FireOnOpenServerListUpdated;
-			_serverDiscovery.StartServerDiscovery(NetworkConfiguration);
-		}
+            _serverDiscovery = new();
+            _serverDiscovery.OnServerDiscoveryActivated += FireOnServerDiscoveryActivated;
+            _serverDiscovery.OnServerDiscoveryDeactivated += FireOnServerDiscoveryDeactivated;
+            _serverDiscovery.OnOpenServerListUpdated += FireOnOpenServerListUpdated;
+            _serverDiscovery.StartServerDiscovery(NetworkConfiguration);
+        }
 
-		/// <summary>
-		/// Ends the Server Discovery unless it is already inactive.
-		/// </summary>
-		public static void EndServerDiscovery()
-		{
-			if (_serverDiscovery == null || !_serverDiscovery.IsActive)
-				return;
+        /// <summary>
+        /// Ends the Server Discovery unless it is already inactive.
+        /// </summary>
+        public static void EndServerDiscovery()
+        {
+            if (_serverDiscovery == null || !_serverDiscovery.IsActive)
+                return;
 
-			_serverDiscovery.EndServerDiscovery();
-			_serverDiscovery.OnServerDiscoveryActivated -= FireOnServerDiscoveryActivated;
-			_serverDiscovery.OnServerDiscoveryDeactivated -= FireOnServerDiscoveryDeactivated;
-			_serverDiscovery.OnOpenServerListUpdated -= FireOnOpenServerListUpdated;
-		}
+            _serverDiscovery.EndServerDiscovery();
+            _serverDiscovery.OnServerDiscoveryActivated -= FireOnServerDiscoveryActivated;
+            _serverDiscovery.OnServerDiscoveryDeactivated -= FireOnServerDiscoveryDeactivated;
+            _serverDiscovery.OnOpenServerListUpdated -= FireOnOpenServerListUpdated;
+        }
 
-		/// <summary>
-		/// Restarts the Server Discovery.
-		/// </summary>
-		public static void RestartServerDiscovery()
-		{
-			EndServerDiscovery();
-			StartServerDiscovery();
-		}
+        /// <summary>
+        /// Restarts the Server Discovery.
+        /// </summary>
+        public static void RestartServerDiscovery()
+        {
+            EndServerDiscovery();
+            StartServerDiscovery();
+        }
 
-		/// <summary>
-		/// Registers a callback for received data structs of type <typeparamref name="T"/>. Only works if the local client is currently connected to a server.
-		/// </summary>
-		/// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
-		/// <param name="callback">Callback containing the sender ID and synchronised data struct</param>
-		public static void RegisterStructData<T>(Action<byte, T> callback) where T : struct, IStructData
-		{
-			if (!IsConnected)
-			{
-				Messaging.DebugMessage("The Client is not connected to a server and can't register any data callbacks!");
-				return;
-			}
+        /// <summary>
+        /// Registers a callback for received data structs of type <typeparamref name="T"/>. Only works if the local client is currently connected to a server.
+        /// </summary>
+        /// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
+        /// <param name="callback">Callback containing the sender ID and synchronised data struct</param>
+        public static void RegisterStructData<T>(Action<byte, T> callback) where T : struct, IStructData
+        {
+            if (!IsConnected)
+            {
+                Messaging.DebugMessage("The Client is not connected to a server and can't register any data callbacks!");
+                return;
+            }
 
-			_networkSocket.RegisterStructData(callback);
-		}
+            _networkSocket.RegisterStructData(callback);
+        }
 
-		/// <summary>
-		/// Unregisters a registered callback for received data structs of type <typeparamref name="T"/>. Only works if the local client is currently connected to a server.
-		/// </summary>
-		/// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
-		/// <param name="callback">Callback containing the sender ID and synchronised data struct</param>
-		public static void UnregisterStructData<T>(Action<byte, T> callback) where T : struct, IStructData
-		{
-			if (!IsConnected)
-			{
-				Messaging.DebugMessage("The Client is not connected to a server and can't unregister any data callbacks!");
-				return;
-			}
+        /// <summary>
+        /// Unregisters a registered callback for received data structs of type <typeparamref name="T"/>. Only works if the local client is currently connected to a server.
+        /// </summary>
+        /// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
+        /// <param name="callback">Callback containing the sender ID and synchronised data struct</param>
+        public static void UnregisterStructData<T>(Action<byte, T> callback) where T : struct, IStructData
+        {
+            if (!IsConnected)
+            {
+                Messaging.DebugMessage("The Client is not connected to a server and can't unregister any data callbacks!");
+                return;
+            }
 
-			_networkSocket.UnregisterStructData(callback);
-		}
+            _networkSocket.UnregisterStructData(callback);
+        }
 
-		/// <summary>
-		/// Registers a callback for received data bytes. Only works if the local client is currently connected to a server.
-		/// </summary>
-		/// <param name="dataID">Global identifier for byte array. Sender and receiver must use the same ID.</param>
-		/// <param name="callback">Callback containing the sender ID and synchronised data bytes</param>
-		public static void RegisterByteData(string dataID, Action<byte, byte[]> callback)
-		{
-			if (!IsConnected)
-			{
-				Messaging.DebugMessage("The Client is not connected to a server and can't register any data callbacks!");
-				return;
-			}
+        /// <summary>
+        /// Registers a callback for received data bytes. Only works if the local client is currently connected to a server.
+        /// </summary>
+        /// <param name="dataID">Global identifier for byte array. Sender and receiver must use the same ID.</param>
+        /// <param name="callback">Callback containing the sender ID and synchronised data bytes</param>
+        public static void RegisterByteData(string dataID, Action<byte, byte[]> callback)
+        {
+            if (!IsConnected)
+            {
+                Messaging.DebugMessage("The Client is not connected to a server and can't register any data callbacks!");
+                return;
+            }
 
-			_networkSocket.RegisterByteData(dataID, callback);
-		}
+            _networkSocket.RegisterByteData(dataID, callback);
+        }
 
-		/// <summary>
-		/// Unregisters a registered callback for received data bytes. Only works if the local client is currently connected to a server.
-		/// </summary>
-		/// <param name="dataID">Global identifier for byte array. Sender and receiver must use the same ID.</param>
-		/// <param name="callback">Callback containing the sender ID and synchronised data bytes</param>
-		public static void UnregisterByteData(string dataID, Action<byte, byte[]> callback)
-		{
-			if (!IsConnected)
-			{
-				Messaging.DebugMessage("The Client is not connected to a server and can't unregister any data callbacks!");
-				return;
-			}
+        /// <summary>
+        /// Unregisters a registered callback for received data bytes. Only works if the local client is currently connected to a server.
+        /// </summary>
+        /// <param name="dataID">Global identifier for byte array. Sender and receiver must use the same ID.</param>
+        /// <param name="callback">Callback containing the sender ID and synchronised data bytes</param>
+        public static void UnregisterByteData(string dataID, Action<byte, byte[]> callback)
+        {
+            if (!IsConnected)
+            {
+                Messaging.DebugMessage("The Client is not connected to a server and can't unregister any data callbacks!");
+                return;
+            }
 
-			_networkSocket.UnregisterByteData(dataID, callback);
-		}
+            _networkSocket.UnregisterByteData(dataID, callback);
+        }
 
-		/// <summary>
-		/// Sends a struct over the network to all other connected clients.
-		/// </summary>
-		/// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
-		/// <param name="structData"></param>
-		/// <param name="networkChannel"></param>
-		/// <param name="onDataSend"></param>
-		public static void SendStructDataToAll<T>(T structData, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
-			Action<bool> onDataSend = null) where T : struct, IStructData
-		{
-			SendStructData(0, structData, networkChannel, onDataSend);
-		}
+        /// <summary>
+        /// Sends a struct over the network to all other connected clients.
+        /// </summary>
+        /// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
+        /// <param name="structData"></param>
+        /// <param name="networkChannel"></param>
+        /// <param name="onDataSend"></param>
+        public static void SendStructDataToAll<T>(T structData, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
+            Action<bool> onDataSend = null) where T : struct, IStructData
+        {
+            SendStructData(0, structData, networkChannel, onDataSend);
+        }
 
-		/// <summary>
-		/// Sends a struct over the network to the server.
-		/// </summary>
-		/// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
-		/// <param name="structData"></param>
-		/// <param name="networkChannel"></param>
-		/// <param name="onDataSend"></param>
-		public static void SendStructDataToServer<T>(T structData, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
-			Action<bool> onDataSend = null) where T : struct, IStructData
-		{
-			SendStructData(1, structData, networkChannel, onDataSend);
-		}
+        /// <summary>
+        /// Sends a struct over the network to the server.
+        /// </summary>
+        /// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
+        /// <param name="structData"></param>
+        /// <param name="networkChannel"></param>
+        /// <param name="onDataSend"></param>
+        public static void SendStructDataToServer<T>(T structData, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
+            Action<bool> onDataSend = null) where T : struct, IStructData
+        {
+            SendStructData(1, structData, networkChannel, onDataSend);
+        }
 
-		/// <summary>
-		/// Sends a struct over the network to a specific client.
-		/// </summary>
-		/// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
-		/// <param name="receiverID"></param>
-		/// <param name="structData"></param>
-		/// <param name="networkChannel"></param>
-		/// <param name="onDataSend"></param>
-		public static void SendStructData<T>(byte receiverID, T structData, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
-			Action<bool> onDataSend = null) where T : struct, IStructData
-		{
-			if (!IsConnected)
-			{
-				Messaging.DebugMessage("The Client is not connected to a server and can't send any data!");
-				onDataSend?.Invoke(false);
-				return;
-			}
+        /// <summary>
+        /// Sends a struct over the network to a specific client.
+        /// </summary>
+        /// <typeparam name="T">A struct implementing IStructData, which containts the to be synchronised data</typeparam>
+        /// <param name="receiverID"></param>
+        /// <param name="structData"></param>
+        /// <param name="networkChannel"></param>
+        /// <param name="onDataSend"></param>
+        public static void SendStructData<T>(byte receiverID, T structData, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
+            Action<bool> onDataSend = null) where T : struct, IStructData
+        {
+            if (!IsConnected)
+            {
+                Messaging.DebugMessage("The Client is not connected to a server and can't send any data!");
+                onDataSend?.Invoke(false);
+                return;
+            }
 
-			_networkSocket.SendStructData(receiverID, structData, networkChannel, onDataSend);
-		}
+            _networkSocket.SendStructData(receiverID, structData, networkChannel, onDataSend);
+        }
 
-		/// <summary>
-		/// Sends a byte array over the network to all other connected clients.
-		/// </summary>
-		/// <param name="dataID"></param>
-		/// <param name="data"></param>
-		/// <param name="networkChannel"></param>
-		/// <param name="onDataSend"></param>
-		public static void SendByteDataToAll(string dataID, byte[] data, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
-			Action<bool> onDataSend = null)
-		{
-			SendByteData(0, dataID, data, networkChannel, onDataSend);
-		}
+        /// <summary>
+        /// Sends a byte array over the network to all other connected clients.
+        /// </summary>
+        /// <param name="dataID"></param>
+        /// <param name="data"></param>
+        /// <param name="networkChannel"></param>
+        /// <param name="onDataSend"></param>
+        public static void SendByteDataToAll(string dataID, byte[] data, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
+            Action<bool> onDataSend = null)
+        {
+            SendByteData(0, dataID, data, networkChannel, onDataSend);
+        }
 
-		/// <summary>
-		/// Sends a byte array over the network to the server.
-		/// </summary>
-		/// <param name="dataID"></param>
-		/// <param name="data"></param>
-		/// <param name="networkChannel"></param>
-		/// <param name="onDataSend"></param>
-		public static void SendByteDataToServer(string dataID, byte[] data, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
-			Action<bool> onDataSend = null)
-		{
-			SendByteData(1, dataID, data, networkChannel, onDataSend);
-		}
+        /// <summary>
+        /// Sends a byte array over the network to the server.
+        /// </summary>
+        /// <param name="dataID"></param>
+        /// <param name="data"></param>
+        /// <param name="networkChannel"></param>
+        /// <param name="onDataSend"></param>
+        public static void SendByteDataToServer(string dataID, byte[] data, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
+            Action<bool> onDataSend = null)
+        {
+            SendByteData(1, dataID, data, networkChannel, onDataSend);
+        }
 
-		/// <summary>
-		/// Sends a byte array over the network to a specific client.
-		/// </summary>
-		/// <param name="receiverID"></param>
-		/// <param name="dataID"></param>
-		/// <param name="data"></param>
-		/// <param name="networkChannel"></param>
-		/// <param name="onDataSend"></param>
-		public static void SendByteData(byte receiverID, string dataID, byte[] data, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
-			Action<bool> onDataSend = null)
-		{
-			if (!IsConnected)
-			{
-				Messaging.DebugMessage("The Client is not connected to a server and can't send any data!");
-				onDataSend?.Invoke(false);
-				return;
-			}
+        /// <summary>
+        /// Sends a byte array over the network to a specific client.
+        /// </summary>
+        /// <param name="receiverID"></param>
+        /// <param name="dataID"></param>
+        /// <param name="data"></param>
+        /// <param name="networkChannel"></param>
+        /// <param name="onDataSend"></param>
+        public static void SendByteData(byte receiverID, string dataID, byte[] data, ENetworkChannel networkChannel = ENetworkChannel.ReliableOrdered,
+            Action<bool> onDataSend = null)
+        {
+            if (!IsConnected)
+            {
+                Messaging.DebugMessage("The Client is not connected to a server and can't send any data!");
+                onDataSend?.Invoke(false);
+                return;
+            }
 
-			_networkSocket.SendByteData(receiverID, dataID, data, networkChannel, onDataSend);
-		}
+            _networkSocket.SendByteData(receiverID, dataID, data, networkChannel, onDataSend);
+        }
 
-		#endregion
+        #endregion
 
-		#region private methods
+        #region private methods
 
-		private static void FireOnConnecting() => OnConnecting?.Invoke();
-		private static void FireOnConnected() => OnConnected?.Invoke();
-		private static void FireOnDisconnected() => OnDisconnected?.Invoke();
-		private static void FireOnConnectionStatusUpdated() => OnConnectionStatusUpdated?.Invoke();
-		private static void FireOnServerWasClosed() => OnServerWasClosed?.Invoke();
-		private static void FireOnClientConnected(byte clientID) => OnClientConnected?.Invoke(clientID);
-		private static void FireOnClientDisconnected(byte clientID) => OnClientDisconnected?.Invoke(clientID);
-		private static void FireOnConnectedClientListUpdated() => OnConnectedClientListUpdated?.Invoke();
-		private static void FireOnServerDiscoveryActivated() => OnServerDiscoveryActivated?.Invoke();
-		private static void FireOnServerDiscoveryDeactivated() => OnServerDiscoveryDeactivated?.Invoke();
-		private static void FireOnOpenServerListUpdated() => OnOpenServerListUpdated?.Invoke();
-		private static void FireOnNetworkMessageAdded() => OnNetworkMessageAdded?.Invoke();
+        private static void FireOnConnecting() => OnConnecting?.Invoke();
+        private static void FireOnConnected() => OnConnected?.Invoke();
+        private static void FireOnDisconnected() => OnDisconnected?.Invoke();
+        private static void FireOnConnectionStatusUpdated() => OnConnectionStatusUpdated?.Invoke();
+        private static void FireOnServerWasClosed() => OnServerWasClosed?.Invoke();
+        private static void FireOnClientConnected(byte clientID) => OnClientConnected?.Invoke(clientID);
+        private static void FireOnClientDisconnected(byte clientID) => OnClientDisconnected?.Invoke(clientID);
+        private static void FireOnConnectedClientListUpdated() => OnConnectedClientListUpdated?.Invoke();
+        private static void FireOnServerDiscoveryActivated() => OnServerDiscoveryActivated?.Invoke();
+        private static void FireOnServerDiscoveryDeactivated() => OnServerDiscoveryDeactivated?.Invoke();
+        private static void FireOnOpenServerListUpdated() => OnOpenServerListUpdated?.Invoke();
+        private static void FireOnNetworkMessageAdded() => OnNetworkMessageAdded?.Invoke();
+
+        private static T LoadOrCreateConfiguration<T>(string name = "NetworkConfiguration", string path = "Assets/Resources/") where T : ScriptableObject
+        {
+            T configuration = Resources.Load<T>(Path.GetFileNameWithoutExtension(name));
 
 #if UNITY_EDITOR
-		private static void ListenForStateChange(bool isActive)
-		{
-			if (isActive)
-				EditorApplication.playModeStateChanged += PreventPlayMode;
-			else
-				EditorApplication.playModeStateChanged -= PreventPlayMode;
-		}
+            string fullPath = path + name + ".asset";
 
-		private static void PreventPlayMode(PlayModeStateChange state)
-		{
-			if (state == PlayModeStateChange.ExitingEditMode)
-				EditorApplication.isPlaying = false;
-		}
+            if (!configuration)
+            {
+                if (EditorApplication.isCompiling)
+                {
+                    UnityEngine.Debug.LogError("Can not load settings when editor is compiling!");
+                    return null;
+                }
+                if (EditorApplication.isUpdating)
+                {
+                    UnityEngine.Debug.LogError("Can not load settings when editor is updating!");
+                    return null;
+                }
+
+                configuration = AssetDatabase.LoadAssetAtPath<T>(fullPath);
+            }
+            if (!configuration)
+            {
+                string[] allSettings = AssetDatabase.FindAssets($"t:{name}{".asset"}");
+                if (allSettings.Length > 0)
+                {
+                    configuration = AssetDatabase.LoadAssetAtPath<T>(AssetDatabase.GUIDToAssetPath(allSettings[0]));
+                }
+            }
+            if (!configuration)
+            {
+                configuration = ScriptableObject.CreateInstance<T>();
+                string dir = Path.GetDirectoryName(fullPath);
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+                AssetDatabase.CreateAsset(configuration, fullPath);
+                AssetDatabase.SaveAssets();
+            }
+
+#else
+			if (!configuration)
+			{
+				configuration = ScriptableObject.CreateInstance<T>();
+			}
+#endif
+            return configuration;
+        }
+
+#if UNITY_EDITOR
+        private static void ListenForStateChange(bool isActive)
+        {
+            if (isActive)
+                EditorApplication.playModeStateChanged += PreventPlayMode;
+            else
+                EditorApplication.playModeStateChanged -= PreventPlayMode;
+        }
+
+        private static void PreventPlayMode(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.ExitingEditMode)
+                EditorApplication.isPlaying = false;
+        }
 #endif
 
-		#endregion
+        #endregion
 
-	}
+    }
 }

--- a/Assets/SimpleUnityNetworking/Runtime/Scripts/Networking/NetworkConfiguration.cs
+++ b/Assets/SimpleUnityNetworking/Runtime/Scripts/Networking/NetworkConfiguration.cs
@@ -8,150 +8,161 @@ using jKnepel.SimpleUnityNetworking.Serialisation;
 
 namespace jKnepel.SimpleUnityNetworking.Networking
 {
-	[CreateAssetMenu(fileName = "NetworkConfiguration", menuName = "SimpleUnityNetworking/NetworkConfiguration")]
-	public class NetworkConfiguration : ScriptableObject
-	{
-		private void OnEnable()
-		{
-			LocalIPAddresses = NetworkUtilities.GetLocalIPAddresses(_allowVirtualIPs);
-			Messaging.ShowDebugMessages = _showDebugMessages;
-		}
+    [CreateAssetMenu(fileName = "NetworkConfiguration", menuName = "SimpleUnityNetworking/NetworkConfiguration")]
+    public class NetworkConfiguration : ScriptableObject
+    {
+        private void OnEnable()
+        {
+            LocalIPAddresses = NetworkUtilities.GetLocalIPAddresses(_allowVirtualIPs);
+            Messaging.ShowDebugMessages = _showDebugMessages;
+        }
 
-		internal const uint PROTOCOL_ID = 876237843;
-		private static byte[] _protocolBytes;
-		internal static byte[] ProtocolBytes
-		{
-			get
-			{
-				if (_protocolBytes != null)
-					return _protocolBytes;
-				Writer writer = new();
-				writer.WriteUInt32(PROTOCOL_ID);
-				return _protocolBytes = writer.GetBuffer();
-			}
-		}
+        internal const uint PROTOCOL_ID = 876237843;
+        private static byte[] _protocolBytes;
+        internal static byte[] ProtocolBytes
+        {
+            get
+            {
+                if (_protocolBytes != null)
+                    return _protocolBytes;
+                Writer writer = new();
+                writer.WriteUInt32(PROTOCOL_ID);
+                return _protocolBytes = writer.GetBuffer();
+            }
+        }
 
-		#region user settings
+        #region user settings
 
-		private string _username = "Username";
-		public string Username
-		{
-			get => _username;
-			set
-			{
-				if (string.IsNullOrEmpty(value))
-				{
-					Messaging.DebugMessage("The Username can't be empty or null!");
-					return;
-				}
+        [SerializeField] private string _username = "Username";
+        public string Username
+        {
+            get => _username;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    Messaging.DebugMessage("The Username can't be empty or null!");
+                    return;
+                }
 
-				if (value.Length > 100)
-				{
-					Messaging.DebugMessage("The Username can't be longer than 100 Characters!");
-				}
+                if (value.Length > 100)
+                {
+                    Messaging.DebugMessage("The Username can't be longer than 100 Characters!");
+                }
 
-				if (Encoding.UTF8.GetByteCount(value) != value.Length)
-				{
-					Messaging.DebugMessage("The Username must be in ASCII Encoding!");
-					return;
-				}
+                if (Encoding.UTF8.GetByteCount(value) != value.Length)
+                {
+                    Messaging.DebugMessage("The Username must be in ASCII Encoding!");
+                    return;
+                }
 
-				_username = value;
-			}
-		}
+                _username = value;
+            }
+        }
 
-		public Color32 Color = new(255, 255, 255, 255);
+        [SerializeField] private Color32 _color = new(255, 255, 255, 255);
+        public Color32 Color { get => _color; set { _color = value; } }
 
-		#endregion
+        #endregion
 
-		#region network configuration settings
+        #region network configuration settings
 
-		[SerializeField] private bool _allowVirtualIPs = false;
-		public bool AllowVirtualIPs
-		{
-			get => _allowVirtualIPs;
-			set
-			{
-				if (_allowVirtualIPs == value)
-					return;
+        [SerializeField] private bool _allowVirtualIPs = false;
+        public bool AllowVirtualIPs
+        {
+            get => _allowVirtualIPs;
+            set
+            {
+                if (_allowVirtualIPs == value)
+                    return;
 
-				_allowVirtualIPs = value;
-				LocalIPAddresses = NetworkUtilities.GetLocalIPAddresses(value);
-			}
-		}
+                _allowVirtualIPs = value;
+                LocalIPAddresses = NetworkUtilities.GetLocalIPAddresses(value);
+            }
+        }
 
-		public string[] LocalStringIPAddresses = new string[0];
-		private IPAddress[] _localIPAddresses = new IPAddress[0];
-		public IPAddress[] LocalIPAddresses
-		{
-			get => _localIPAddresses;
-			internal set
-			{
-				_localIPAddresses = value;
-				LocalIPAddressIndex = Math.Min(LocalIPAddressIndex, LocalIPAddresses.Length - 1);
-				LocalStringIPAddresses = value.Select(x => x.ToString()).ToArray();
-			}
-		}
+        private string[] _localStringIPAddresses = new string[0];
+        public string[] LocalStringIPAddresses { get => _localStringIPAddresses; set => _localStringIPAddresses = value; }
 
-		private int _localIPAddressIndex = 0;
-		public int LocalIPAddressIndex
-		{
-			get => _localIPAddressIndex;
-			set
-			{
-				if (_localIPAddressIndex != value && value < LocalIPAddresses.Length)
-					_localIPAddressIndex = value;
-			}
-		}
+        private IPAddress[] _localIPAddresses = new IPAddress[0];
+        public IPAddress[] LocalIPAddresses
+        {
+            get => _localIPAddresses;
+            internal set
+            {
+                _localIPAddresses = value;
+                LocalIPAddressIndex = Math.Min(LocalIPAddressIndex, LocalIPAddresses.Length - 1);
+                LocalStringIPAddresses = value.Select(x => x.ToString()).ToArray();
+            }
+        }
 
-		private int _localPort = 0;
-		public int LocalPort { get => _localPort; internal set => _localPort = value; }
+        private int _localIPAddressIndex = 0;
+        public int LocalIPAddressIndex
+        {
+            get => _localIPAddressIndex;
+            set
+            {
+                if (_localIPAddressIndex != value && value < LocalIPAddresses.Length)
+                    _localIPAddressIndex = value;
+            }
+        }
 
+        private int _localPort = 0;
+        public int LocalPort { get => _localPort; internal set => _localPort = value; }
 
-		public int MTU = 1200;
-		public int RTT = 200;
-		public int ServerConnectionTimeout = 5000;
-		public int ServerHeartbeatDelay = 1000;
-		public int ServerDiscoveryTimeout = 3000;
-		public int MaxNumberResendReliablePackets = 5;
+        [SerializeField] private int _mtu = 1200;
+        public int MTU { get => _mtu; set => _mtu = value; }
+        [SerializeField] private int _rtt = 200;
+        public int RTT { get => _rtt; set => _rtt = value; }
+        [SerializeField] private int _serverConnectionTimeout = 5000;
+        public int ServerConnectionTimeout { get => _serverConnectionTimeout; set => _serverConnectionTimeout = value; }
+        [SerializeField] private int _serverHeartbeatDelay = 1000;
+        public int ServerHeartbeatDelay { get => _serverHeartbeatDelay; set => _serverHeartbeatDelay = value; }
+        [SerializeField] private int _serverDiscoveryTimeout = 3000;
+        public int ServerDiscoveryTimeout { get => _serverDiscoveryTimeout; set => _serverDiscoveryTimeout = value; }
+        [SerializeField] private int _maxNumberResendReliablePackets = 5;
+        public int MaxNumberResendReliablePackets { get => _maxNumberResendReliablePackets; set => _maxNumberResendReliablePackets = value; }
 
-		#endregion
+        #endregion
 
-		#region server discovery settings
+        #region server discovery settings
 
-		public string DiscoveryIP = "239.240.240.149";
+        [SerializeField] private string _discoveryIP = "239.240.240.149";
+        public string DiscoveryIP { get => _discoveryIP; set => _discoveryIP = value; }
 
-		private int _discoveryPort = 26824;
-		public int DiscoveryPort
-		{
-			get => _discoveryPort;
-			set
-			{
-				if (_discoveryPort == value)
-					return;
+        [SerializeField] private int _discoveryPort = 26824;
+        public int DiscoveryPort
+        {
+            get => _discoveryPort;
+            set
+            {
+                if (_discoveryPort == value)
+                    return;
 
-				if (value < IPEndPoint.MinPort || value > IPEndPoint.MaxPort)
-				{
-					Messaging.DebugMessage("The given Port number is outside the accepted Range!");
-					return;
-				}
+                if (value < IPEndPoint.MinPort || value > IPEndPoint.MaxPort)
+                {
+                    Messaging.DebugMessage("The given Port number is outside the accepted Range!");
+                    return;
+                }
 
-				_discoveryPort = value;
-			}
-		}
+                _discoveryPort = value;
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region debug settings
+        #region debug settings
 
-		[SerializeField] private bool _showDebugMessages = true;
-		public bool ShowDebugMessages
-		{
-			get => _showDebugMessages;
-			set => Messaging.ShowDebugMessages = _showDebugMessages = value;
-		}
-		public bool AllowLocalConnections = false;
+        [SerializeField] private bool _showDebugMessages = true;
+        public bool ShowDebugMessages
+        {
+            get => _showDebugMessages;
+            set => Messaging.ShowDebugMessages = _showDebugMessages = value;
+        }
 
-		#endregion
-	}
+        [SerializeField] private bool _allowLocalConnections = false;
+        public bool AllowLocalConnections { get => _allowLocalConnections; set => _allowLocalConnections = value; }
+
+        #endregion
+    }
 }


### PR DESCRIPTION
Fixed static network manager window:
- Reference is now saved
- Small refactoring to better understand what configuration values are being saved 